### PR TITLE
Backfill missing lab metadata (3 files)

### DIFF
--- a/Instructions/Labs/01-interact-with-an-api.md
+++ b/Instructions/Labs/01-interact-with-an-api.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: 'Interact with an ASP.NET Core minimal API'
-    description: 'In this exercise, you run an ASP.NET Core minimal API locally and explore the API and the underlying code. You also publish the API to Azure App Service.'
+  title: Interact with an ASP.NET Core minimal API
+  description: In this exercise, you run an ASP.NET Core minimal API locally and explore
+    the API and the underlying code. You also publish the API to Azure App Service.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - .NET
+  - ASP.NET
+  - ASP.NET Core
+  - Azure
+  - Azure App Service
 ---
 
 # Interact with an ASP.NET Core minimal API

--- a/Instructions/Labs/02-implement-http-operations.md
+++ b/Instructions/Labs/02-implement-http-operations.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Implement HTTP operations in ASP.NET Core Blazor Web apps'
-    description: 'Learn how to add implement an HTTP client and perform GET, POST, PUT, and DELETE operations.'
+  title: Implement HTTP operations in ASP.NET Core Blazor Web apps
+  description: Learn how to add implement an HTTP client and perform GET, POST, PUT,
+    and DELETE operations.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - .NET
+  - Blazor
+  - ASP.NET
+  - ASP.NET Core
 ---
 
 # Implement HTTP operations in ASP.NET Core Blazor Web apps

--- a/Instructions/Labs/03-render-api-results-razor-pages.md
+++ b/Instructions/Labs/03-render-api-results-razor-pages.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Render API responses in ASP.NET Core Blazor Web apps'
-    description: 'Learn how to render results from HTTP operations in an ASP.NET Core Blazor web app.'
+  title: Render API responses in ASP.NET Core Blazor Web apps
+  description: Learn how to render results from HTTP operations in an ASP.NET Core
+    Blazor web app.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - .NET
+  - Blazor
+  - ASP.NET
+  - ASP.NET Core
 ---
 
 # Render API responses in ASP.NET Core Blazor Web apps


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 3

- `Instructions/Labs/01-interact-with-an-api.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/02-implement-http-operations.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/03-render-api-results-razor-pages.md` (duration,level,islab,primarytopics)
